### PR TITLE
fix: handle table rows without children to avoid iterator error

### DIFF
--- a/src/mdast-table-handler.js
+++ b/src/mdast-table-handler.js
@@ -39,6 +39,9 @@ function toGridCell(cell, state) {
 }
 
 function toGridRow(row, state) {
+  if (!row.children) {
+    return null;
+  }
   return {
     ...row,
     children: row.children.map((cell) => toGridCell(cell, state)),
@@ -47,7 +50,9 @@ function toGridRow(row, state) {
 }
 
 function toGridRows(rows, state) {
-  return rows.map((r) => toGridRow(r, state));
+  return rows
+    .map((r) => toGridRow(r, state))
+    .filter(Boolean);
 }
 
 const tableToGridTable = (table, state) => {

--- a/test/roundtrip/roundtrip-fixtures/tables.input.html
+++ b/test/roundtrip/roundtrip-fixtures/tables.input.html
@@ -99,6 +99,13 @@
             </div>
           </div>
         </div>
+        <div>
+          <div>
+            <div>
+              <table><thead><!-- comment causes node.children to be missing --></thead></table>
+            </div>
+          </div>
+        </div>
       </div>
     </main>
     <footer></footer>


### PR DESCRIPTION
## Summary

- Guard against table row nodes with missing `children` (e.g. `<thead>` containing only HTML comments)
- Filter `null` rows from `toGridRows` so downstream code doesn't iterate over undefined children
- Add a roundtrip fixture that reproduces the edge case

- fixes [#965](https://github.com/adobe/helix-html2md-service/issues/965)

## Test plan

- [x] Added test fixture `tables.input.html` with a `<thead><!-- comment --></thead>` to reproduce the crash
- [x] `toGridRow` now returns `null` for rows without `children`
- [x] `toGridRows` filters out `null` entries before returning

🤖 Generated with [Claude Code](https://claude.com/claude-code)