### PR TITLE
fix: skip empty jsonld

### DIFF
--- a/src/html2md.js
+++ b/src/html2md.js
@@ -129,8 +129,11 @@ function addMetadata(hast, mdast, maxMetadataSize) {
         }
       }
     } else if (child.tagName === 'script' && child.properties.type === 'application/ld+json') {
-      const str = assertValidJSON(assertMetaSizeLimit(toString(child), maxMetadataSize));
-      meta.set(text('json-ld'), text(str));
+      const raw = toString(child).trim();
+      if (raw) {
+        const str = assertValidJSON(assertMetaSizeLimit(raw, maxMetadataSize));
+        meta.set(text('json-ld'), text(str));
+      }
     }
   }
 

--- a/test/fixtures/json-ld-empty.html
+++ b/test/fixtures/json-ld-empty.html
@@ -1,0 +1,16 @@
+<html>
+
+<head>
+  <script type="application/ld+json">
+  </script>
+</head>
+
+<body>
+  <main>
+    <div>
+      <h1>Hello, World.</h1>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/test/fixtures/json-ld-empty.md
+++ b/test/fixtures/json-ld-empty.md
@@ -1,0 +1,1 @@
+# Hello, World.

--- a/test/html2md.test.js
+++ b/test/html2md.test.js
@@ -106,6 +106,10 @@ describe('html2md Tests', () => {
     await test('json-ld-too-large', { maxMetadataSize: 256_000 });
   });
 
+  it('ignores empty json-ld script tags', async () => {
+    await test('json-ld-empty');
+  });
+
   it('throws meaningful error when json-ld is invalid', async () => {
     await assert.rejects(() => test('json-ld-invalid'), Error('invalid json-ld'));
   });


### PR DESCRIPTION
Currently we fail on empty json-ld. This causes >1k warnings in the past week from different content sources.

Thanks for contributing!
