### PR TITLE
fix: accept http:// and case-insensitive URL schemes for external images

### DIFF
--- a/src/mdast-process-images.js
+++ b/src/mdast-process-images.js
@@ -74,7 +74,7 @@ export async function processImages(
         // eslint-disable-next-line no-param-reassign
         node.url = new URL(url, baseUrl).href;
         register(node);
-      } else if (url.startsWith('https://')) {
+      } else if (/^https?:\/\//i.test(url)) {
         register(node);
       }
     }

--- a/test/mdast-process-images.test.js
+++ b/test/mdast-process-images.test.js
@@ -601,4 +601,50 @@ describe('mdast-process-images Tests', () => {
     assert.ok(processedUrls.includes('https://example.com/image1.jpg'), 'First image should be processed');
     assert.ok(processedUrls.includes('https://example.com/image2.jpg'), 'Second image should be processed');
   });
+
+  it('registers http:// and case-insensitive scheme URLs', async () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'image',
+              url: 'http://example.com/image.jpg',
+              alt: 'http image',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'image',
+              url: 'HTTP://example.com/image2.jpg',
+              alt: 'uppercase HTTP image',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'image',
+              url: 'HTTPS://example.com/image3.jpg',
+              alt: 'uppercase HTTPS image',
+            },
+          ],
+        },
+      ],
+    };
+
+    processedUrls = [];
+    await processImages(mockLog, tree, mockMediaHandler, baseUrl, []);
+
+    assert.strictEqual(processedUrls.length, 3, 'all three images should be registered');
+    assert.ok(processedUrls.includes('http://example.com/image.jpg'), 'http:// image should be processed');
+    assert.ok(processedUrls.includes('HTTP://example.com/image2.jpg'), 'HTTP:// image should be processed');
+    assert.ok(processedUrls.includes('HTTPS://example.com/image3.jpg'), 'HTTPS:// image should be processed');
+  });
 });


### PR DESCRIPTION
## Summary
- Replaced `url.startsWith('https://')` with `/^https?:\/\//i.test(url)` in `processImages`
- Now registers plain `http://` image URLs for upload (previously silently skipped)
- Now registers mixed-case schemes (`HTTP://`, `HTTPS://`) via case-insensitive flag

## Test plan
- [x] Added test case `registers http:// and case-insensitive scheme URLs` covering `http://`, `HTTP://`, and `HTTPS://` inputs
- [x] All 52 tests pass, 100% branch/statement/function/line coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)