### PR TITLE
Preserve DM url in og:image without FF

### DIFF
--- a/src/html2md.js
+++ b/src/html2md.js
@@ -62,6 +62,10 @@ function image(url) {
   return {
     type: 'image',
     url,
+    // distinguishes a page-metadata image (og:image, twitter:image, etc.) from a
+    // regular body image node, so downstream processing (see isAdobeAssetDeliveryUrl
+    // in mdast-process-images.js) can treat them differently.
+    isMetadataImage: true,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@
  * governing permissions and limitations under the License.
  */
 export * from './html2md.js';
-export { TooManyImagesError } from './mdast-process-images.js';
+export { TooManyImagesError, isAdobeAssetDeliveryUrl } from './mdast-process-images.js';
 export { ImageUploadError } from './image-upload-error.js';

--- a/src/mdast-process-images.js
+++ b/src/mdast-process-images.js
@@ -18,6 +18,32 @@ export class TooManyImagesError extends Error {
 }
 
 /**
+ * URL patterns for Adobe Assets / Dynamic Media delivery endpoints. Images served from
+ * these URLs are already on Adobe's own optimized asset delivery CDN, so they're kept
+ * as external references instead of being downloaded and rehosted into the site's own
+ * media store - regardless of imageFilter/externalImageUrlPrefixes configuration.
+ * @constant {RegExp[]}
+ */
+const ADOBE_ASSET_DELIVERY_PATTERNS = [
+  // Dynamic Media with OpenAPI / AEM Assets delivery, e.g.
+  // https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:.../as/foo.jpg
+  // Anchored on the adobeaemcloud.com domain (not just the path shape) so this can't
+  // accidentally match an unrelated host that merely has a similarly-shaped path.
+  /^https?:\/\/[^/]+\.adobeaemcloud\.com\/adobe\/assets\/urn:aaid:aem:/i,
+  // Dynamic Media classic / Scene7, e.g. https://s7ap1.scene7.com/is/image/foo/bar
+  /^https?:\/\/[^/]+\.scene7\.com\/is\/image\//i,
+];
+
+/**
+ * Checks if a URL is a known Adobe Assets / Dynamic Media delivery URL.
+ * @param {string} url The URL to check
+ * @returns {boolean} Whether the URL matches a known Adobe Assets/Dynamic Media pattern
+ */
+export function isAdobeAssetDeliveryUrl(url) {
+  return ADOBE_ASSET_DELIVERY_PATTERNS.some((pattern) => pattern.test(url));
+}
+
+/**
  * Process images
  * @param {Console} log
  * @param {object} tree
@@ -42,6 +68,10 @@ export async function processImages(
 
   const register = (node) => {
     const { url = '' } = node;
+    if (isAdobeAssetDeliveryUrl(url)) {
+      log.debug(`Skipping upload for Adobe Assets/Dynamic Media URL: ${url}`);
+      return;
+    }
     if (!imageFilter(url)) {
       log.debug(`Skipping upload for image: ${url}`);
       return;

--- a/src/mdast-process-images.js
+++ b/src/mdast-process-images.js
@@ -19,9 +19,12 @@ export class TooManyImagesError extends Error {
 
 /**
  * URL patterns for Adobe Assets / Dynamic Media delivery endpoints. Images served from
- * these URLs are already on Adobe's own optimized asset delivery CDN, so they're kept
- * as external references instead of being downloaded and rehosted into the site's own
- * media store - regardless of imageFilter/externalImageUrlPrefixes configuration.
+ * these URLs are already on Adobe's own optimized asset delivery CDN, so - when used as
+ * page-metadata images (og:image, twitter:image, etc.) - they're kept as external
+ * references instead of being downloaded and rehosted into the site's own media store,
+ * regardless of imageFilter/externalImageUrlPrefixes configuration. Regular body images
+ * are unaffected and keep today's exact rehosting behavior; see the isMetadataImage
+ * check in processImages/register below.
  * @constant {RegExp[]}
  */
 const ADOBE_ASSET_DELIVERY_PATTERNS = [
@@ -68,8 +71,10 @@ export async function processImages(
 
   const register = (node) => {
     const { url = '' } = node;
-    if (isAdobeAssetDeliveryUrl(url)) {
-      log.debug(`Skipping upload for Adobe Assets/Dynamic Media URL: ${url}`);
+    // only page-metadata images (og:image, twitter:image, etc.) get this exemption -
+    // regular body images are unaffected and keep today's exact rehosting behavior.
+    if (node.isMetadataImage && isAdobeAssetDeliveryUrl(url)) {
+      log.debug(`Skipping upload for Adobe Assets/Dynamic Media metadata URL: ${url}`);
       return;
     }
     if (!imageFilter(url)) {

--- a/test/html2md.test.js
+++ b/test/html2md.test.js
@@ -197,6 +197,51 @@ describe('html2md Tests', () => {
     assert.deepStrictEqual(processedUrls, ['https://keep.com/image.jpg']);
   });
 
+  it('preserves Adobe Assets/Dynamic Media delivery URLs by default, without any filter configured', async () => {
+    const html = '<html><body><main><div>'
+      + '<img src="https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg">'
+      + '<img src="https://s7ap1.scene7.com/is/image/mycompany/bar">'
+      + '<img src="https://keep.com/image.jpg">'
+      + '</div></main></body></html>';
+    const processedUrls = [];
+    const mediaHandler = {
+      getBlob: async (url) => {
+        processedUrls.push(url);
+        return { uri: url };
+      },
+    };
+    // deliberately no imageFilter / externalImageUrlPrefixes passed
+    const md = await html2md(html, {
+      log: console,
+      url: 'https://example.com',
+      mediaHandler,
+    });
+    assert.deepStrictEqual(processedUrls, ['https://keep.com/image.jpg']);
+    assert.ok(md.includes('https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg'));
+    assert.ok(md.includes('https://s7ap1.scene7.com/is/image/mycompany/bar'));
+  });
+
+  it('preserves an Adobe Assets/Dynamic Media URL used as og:image, without any filter configured', async () => {
+    const html = '<html><head>'
+      + '<meta property="og:image" content="https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:67890/as/hero.jpg">'
+      + '</head><body><main><div><h1>Hello</h1></div></main></body></html>';
+    const processedUrls = [];
+    const mediaHandler = {
+      getBlob: async (url) => {
+        processedUrls.push(url);
+        return { uri: url };
+      },
+    };
+    // deliberately no imageFilter / externalImageUrlPrefixes passed
+    const md = await html2md(html, {
+      log: console,
+      url: 'https://example.com',
+      mediaHandler,
+    });
+    assert.deepStrictEqual(processedUrls, []);
+    assert.ok(md.includes('https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:67890/as/hero.jpg'));
+  });
+
   it('convert nested tables', async () => {
     await test('tables');
   });

--- a/test/html2md.test.js
+++ b/test/html2md.test.js
@@ -197,7 +197,9 @@ describe('html2md Tests', () => {
     assert.deepStrictEqual(processedUrls, ['https://keep.com/image.jpg']);
   });
 
-  it('preserves Adobe Assets/Dynamic Media delivery URLs by default, without any filter configured', async () => {
+  it('does NOT exempt Adobe Assets/Dynamic Media URLs used as regular body images', async () => {
+    // the exemption is scoped to page-metadata images only (see next test) - a body
+    // image using the same kind of URL keeps today's exact rehosting behavior.
     const html = '<html><body><main><div>'
       + '<img src="https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg">'
       + '<img src="https://s7ap1.scene7.com/is/image/mycompany/bar">'
@@ -211,14 +213,16 @@ describe('html2md Tests', () => {
       },
     };
     // deliberately no imageFilter / externalImageUrlPrefixes passed
-    const md = await html2md(html, {
+    await html2md(html, {
       log: console,
       url: 'https://example.com',
       mediaHandler,
     });
-    assert.deepStrictEqual(processedUrls, ['https://keep.com/image.jpg']);
-    assert.ok(md.includes('https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg'));
-    assert.ok(md.includes('https://s7ap1.scene7.com/is/image/mycompany/bar'));
+    assert.deepStrictEqual(processedUrls, [
+      'https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg',
+      'https://s7ap1.scene7.com/is/image/mycompany/bar',
+      'https://keep.com/image.jpg',
+    ]);
   });
 
   it('preserves an Adobe Assets/Dynamic Media URL used as og:image, without any filter configured', async () => {

--- a/test/mdast-process-images.test.js
+++ b/test/mdast-process-images.test.js
@@ -13,7 +13,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import { SizeTooLargeException } from '@adobe/helix-mediahandler';
-import { processImages, TooManyImagesError } from '../src/mdast-process-images.js';
+import { processImages, TooManyImagesError, isAdobeAssetDeliveryUrl } from '../src/mdast-process-images.js';
 import { ImageUploadError } from '../src/image-upload-error.js';
 import { imageFilterFromPrefixes } from '../src/html2md.js';
 
@@ -594,5 +594,65 @@ describe('mdast-process-images Tests', () => {
     assert.ok(processedUrls.includes('http://example.com/image.jpg'), 'http:// image should be processed');
     assert.ok(processedUrls.includes('HTTP://example.com/image2.jpg'), 'HTTP:// image should be processed');
     assert.ok(processedUrls.includes('HTTPS://example.com/image3.jpg'), 'HTTPS:// image should be processed');
+  });
+
+  describe('isAdobeAssetDeliveryUrl', () => {
+    it('matches Dynamic Media OpenAPI / AEM Assets delivery URLs', () => {
+      assert.ok(isAdobeAssetDeliveryUrl('https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/foo.jpg'));
+    });
+
+    it('matches Scene7 / Dynamic Media classic URLs', () => {
+      assert.ok(isAdobeAssetDeliveryUrl('https://s7ap1.scene7.com/is/image/mycompany/bar'));
+    });
+
+    it('does not match unrelated or spoofed domains', () => {
+      assert.ok(!isAdobeAssetDeliveryUrl('https://example.com/adobe/assets/urn:aaid:aem:12345'));
+      assert.ok(!isAdobeAssetDeliveryUrl('https://evil-adobeaemcloud.com/adobe/assets/urn:aaid:aem:x'));
+      assert.ok(!isAdobeAssetDeliveryUrl('https://foo.adobeaemcloud.com.evil.com/adobe/assets/urn:aaid:aem:x'));
+    });
+  });
+
+  describe('page-metadata image exemption scoping', () => {
+    it('skips upload for a page-metadata image on a known Adobe Assets/Dynamic Media URL', async () => {
+      const tree = {
+        type: 'root',
+        children: [
+          {
+            type: 'image',
+            url: 'https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/hero.jpg',
+            isMetadataImage: true,
+          },
+        ],
+      };
+
+      await processImages(mockLog, tree, mockMediaHandler, baseUrl);
+
+      assert.strictEqual(processedUrls.length, 0, 'metadata image on a known Adobe Assets URL should not be uploaded');
+      assert.strictEqual(
+        tree.children[0].url,
+        'https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/hero.jpg',
+      );
+    });
+
+    it('still uploads a regular body image on the same kind of Adobe Assets/Dynamic Media URL', async () => {
+      const tree = {
+        type: 'root',
+        children: [
+          {
+            type: 'image',
+            url: 'https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/hero.jpg',
+            // no isMetadataImage flag - this is a regular body image
+          },
+        ],
+      };
+
+      await processImages(mockLog, tree, mockMediaHandler, baseUrl);
+
+      assert.deepStrictEqual(
+        processedUrls,
+        ['https://delivery-p123-e456.adobeaemcloud.com/adobe/assets/urn:aaid:aem:12345/as/hero.jpg'],
+        'regular body image should still be uploaded even on a known Adobe Assets URL',
+      );
+    });
   });
 });


### PR DESCRIPTION
Preserve Adobe Assets/Dynamic Media delivery URLs (*.adobeaemcloud.com/adobe/assets/..., *.scene7.com/is/image/...) as-is when used as page-metadata images (og:image, twitter:image, etc.), instead of rehosting them into the site's local media bucket by default.

Scoped narrowly to metadata images only, via a new isMetadataImage flag on nodes from addMetadata() — regular body images on the same kind of URL are unaffected and keep today's exact rehosting behavior, no config required.

Added isAdobeAssetDeliveryUrl() (domain-anchored, not path-shape-based, to avoid false positives) plus unit and integration tests covering both the exemption and the negative case (body image still uploads).


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
